### PR TITLE
Refactor core module into smaller components

### DIFF
--- a/fm_tool_core/constants.py
+++ b/fm_tool_core/constants.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+READY_NAME = "PY_READY_FLAG"
+READY_OK = "READY"
+READY_ERR = "ERROR"
+
+READY_TO = 600  # seconds
+OPEN_TO = 60
+POLL_SLEEP = 0.25
+RETRY_SLEEP = 2
+
+LOG_DIR = Path(os.getenv("LOG_DIR", "./logs")).resolve()
+
+SP_USERNAME = os.getenv("SP_USERNAME")
+SP_PASSWORD = os.getenv("SP_PASSWORD")
+ROOT_SP_SITE = "https://ksmcpa.sharepoint.com/teams/ksmta"
+
+SCAC_VALIDATION_SHEET = "HOME"
+VISIBLE_EXCEL = os.getenv("FM_SHOW_EXCEL", "0") == "1"
+
+__all__ = [
+    "READY_NAME",
+    "READY_OK",
+    "READY_ERR",
+    "READY_TO",
+    "OPEN_TO",
+    "POLL_SLEEP",
+    "RETRY_SLEEP",
+    "LOG_DIR",
+    "SP_USERNAME",
+    "SP_PASSWORD",
+    "ROOT_SP_SITE",
+    "SCAC_VALIDATION_SHEET",
+    "VISIBLE_EXCEL",
+]

--- a/fm_tool_core/excel_utils.py
+++ b/fm_tool_core/excel_utils.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from .constants import (
+    OPEN_TO,
+    POLL_SLEEP,
+    READY_ERR,
+    READY_NAME,
+    READY_OK,
+    READY_TO,
+    SCAC_VALIDATION_SHEET,
+    VISIBLE_EXCEL,
+)
+from .exceptions import FlowError
+
+# psutil may be unavailable in tests
+try:  # pragma: no cover - platform specific
+    import psutil
+except Exception:  # pragma: no cover - missing dependency
+
+    class _PS:
+        @staticmethod
+        def process_iter(attrs=None):
+            return []
+
+    psutil = _PS()
+
+# xlwings may be unavailable in tests
+try:  # pragma: no cover - heavy dependency
+    import xlwings as xw
+except Exception:  # pragma: no cover - missing dependency
+    xw = None  # type: ignore
+
+# win32com is Windows-only; provide no-op fallback
+try:  # pragma: no cover - platform specific
+    from win32com.client import pythoncom  # type: ignore
+except Exception:  # pragma: no cover - non-Windows
+
+    class _PC:
+        @staticmethod
+        def PumpWaitingMessages(): ...
+
+        @staticmethod
+        def CoInitialize(): ...
+
+        @staticmethod
+        def CoUninitialize(): ...
+
+    pythoncom = _PC()
+
+
+def kill_orphan_excels():
+    for p in psutil.process_iter(attrs=["name"]):
+        if p.info.get("name", "").lower().startswith("excel"):
+            try:
+                p.kill()
+            except Exception:
+                pass
+
+
+def copy_template(src: str, dst_root: str, new_name: str, log: logging.Logger) -> Path:
+    src_path = Path(src)
+    if not src_path.exists():
+        raise FlowError(f"Template not found: {src}", work_completed=False)
+
+    dst_root = Path(dst_root).expanduser().resolve()
+    dst_root.mkdir(parents=True, exist_ok=True)
+    dst = dst_root / new_name
+
+    try:
+        shutil.copy2(src_path, dst)
+    except PermissionError:
+        log.warning("Destination locked; unlinking and retrying copy")
+        try:
+            dst.unlink()
+        except Exception:
+            pass
+        shutil.copy2(src_path, dst)
+
+    return dst
+
+
+def wait_ready(wb, log: logging.Logger):
+    start = time.time()
+    last_log = -999
+    while True:
+        try:
+            ref = wb.names[READY_NAME].refers_to
+            if ref.startswith("="):
+                ref = ref[1:]
+            flag = ref.strip('"').strip()
+        except Exception:
+            flag = "<not-set>"
+
+        elapsed = int(time.time() - start)
+        if elapsed != last_log:
+            log.info("Polling flag: %s (t=%ss)", flag, elapsed)
+            last_log = elapsed
+
+        if flag == READY_OK:
+            return
+        if flag == READY_ERR:
+            raise FlowError("VBA signaled ERROR", work_completed=False)
+        if elapsed >= READY_TO:
+            raise FlowError("Timeout waiting for READY flag", work_completed=False)
+        time.sleep(POLL_SLEEP)
+
+
+def _open_excel_with_timeout(path: Path, log: logging.Logger):
+    if xw is None:
+        raise FlowError("xlwings is required", work_completed=False)
+
+    log.info("Creating Excel App …")
+    app = xw.App(visible=VISIBLE_EXCEL, add_book=False)  # type: ignore
+    app.api.DisplayFullScreen = False
+    app.api.Application.DisplayAlerts = False
+
+    log.info("Opening workbook …")
+    t0 = time.time()
+    while True:
+        try:
+            book = app.books.open(str(path))
+            return app, book
+        except Exception as e:
+            if time.time() - t0 > OPEN_TO:
+                log.error("Excel open timed out after %s s", OPEN_TO)
+                try:
+                    app.kill()
+                except Exception:
+                    pass
+                raise FlowError(f"Excel failed to open workbook: {e}", False)
+            pythoncom.PumpWaitingMessages()
+            time.sleep(0.5)
+
+
+def _run_macro_impl(wb_path: Path, args: tuple, log: logging.Logger):
+    app, wb = _open_excel_with_timeout(wb_path, log)
+    try:
+        log.info("Running macro PopulateAndRunReport …")
+        wb.macro("PopulateAndRunReport")(*args)
+        wait_ready(wb, log)
+        wb.api.Application.CalculateFull()
+        wb.save()
+        log.info("Workbook saved")
+    finally:
+        for op in (wb.close, app.kill):
+            try:
+                op()
+            except Exception:
+                pass
+
+
+def run_excel_macro(wb_path: Path, args: tuple, log: logging.Logger):
+    exc: list[Exception] = []
+
+    def _worker():
+        try:
+            pythoncom.CoInitialize()
+            _run_macro_impl(wb_path, args, log)
+        except Exception as e:
+            exc.append(e)
+        finally:
+            try:
+                pythoncom.CoUninitialize()
+            except Exception:
+                pass
+
+    th = threading.Thread(target=_worker, daemon=True)
+    th.start()
+
+    start = time.time()
+    while th.is_alive():
+        time.sleep(0.5)
+        if time.time() - start > READY_TO:
+            log.error("Macro exceeded %s s – killing Excel", READY_TO)
+            kill_orphan_excels()
+            raise FlowError("Timeout running macro", work_completed=False)
+
+    if exc:
+        raise exc[0]
+
+
+def read_cell(wb_path: Path, col: str, row: str) -> Any:
+    if xw is None:
+        raise FlowError("xlwings is required", work_completed=False)
+
+    app = xw.App(visible=VISIBLE_EXCEL, add_book=False)  # type: ignore
+    app.api.DisplayFullScreen = False
+    try:
+        wb = app.books.open(str(wb_path))
+        value = wb.sheets[SCAC_VALIDATION_SHEET].range(f"{col}{row}").value
+    finally:
+        for op in (wb.close, app.kill):  # type: ignore
+            try:
+                op()
+            except Exception:
+                pass
+    return value
+
+
+__all__ = [
+    "kill_orphan_excels",
+    "copy_template",
+    "wait_ready",
+    "run_excel_macro",
+    "read_cell",
+]

--- a/fm_tool_core/exceptions.py
+++ b/fm_tool_core/exceptions.py
@@ -1,0 +1,12 @@
+class FlowError(Exception):
+    """Domain-specific exception returned to Power Automate Cloud Flow."""
+
+    def __init__(self, msg: str, *, work_completed: bool = False) -> None:
+        super().__init__(msg)
+        self.work_completed = work_completed
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.args[0]
+
+
+__all__ = ["FlowError"]

--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -1,24 +1,13 @@
 #!/usr/bin/env python3
 """
-process_fm_tool.py   –   2025-06-25
-
-Stable Excel automation for FM-Tool processing
-──────────────────────────────────────────────
-• Unique working filename per run
-• Step-level logging, open/macro time-outs
-• Ctrl-C responsive
-• READY-flag normalization (=READY → READY) so polling exits correctly
+FM Tool processing entry points.
 """
-
 from __future__ import annotations
 
 import argparse
 import json
 import logging
-import os
-import shutil
 import sys
-import threading
 import time
 import uuid
 from datetime import datetime
@@ -26,221 +15,26 @@ from pathlib import Path
 from typing import Any, Dict, List
 from urllib.parse import urlparse
 
-import psutil
-import xlwings as xw
-from office365.runtime.auth.user_credential import UserCredential
-from office365.sharepoint.client_context import ClientContext
-
-# win32com is Windows-only; provide no-op fallback for tests / non-Windows
-try:
-    from win32com.client import pythoncom  # type: ignore
-except Exception:  # pragma: no cover
-
-    class _PC:
-        @staticmethod
-        def PumpWaitingMessages(): ...
-        @staticmethod
-        def CoInitialize(): ...
-        @staticmethod
-        def CoUninitialize(): ...
-
-    pythoncom = _PC()
-
-# ---------- CONSTANTS ---------------------------------------------------- #
-READY_NAME, READY_OK, READY_ERR = "PY_READY_FLAG", "READY", "ERROR"
-READY_TO, OPEN_TO, POLL_SLEEP, RETRY_SLEEP = 600, 60, 0.25, 2  # seconds
-LOG_DIR = Path(os.getenv("LOG_DIR", "./logs")).resolve()
-SP_USERNAME, SP_PASSWORD = os.getenv("SP_USERNAME"), os.getenv("SP_PASSWORD")
-# The site collection under which our service account lives
-ROOT_SP_SITE = "https://ksmcpa.sharepoint.com/teams/ksmta"
-# Sheet that holds the validation cells
-SCAC_VALIDATION_SHEET = "HOME"
-# Show the Excel UI when FM_SHOW_EXCEL=1
-VISIBLE_EXCEL = os.getenv("FM_SHOW_EXCEL", "0") == "1"
-# ------------------------------------------------------------------------ #
-
-
-class FlowError(Exception):
-    """Domain-specific exception returned to Power Automate Cloud Flow."""
-
-    def __init__(self, msg: str, *, work_completed: bool = False) -> None:
-        super().__init__(msg)
-        self.work_completed = work_completed
-
-    def __str__(self) -> str:
-        return self.args[0]
-
-
-# -------------------- PROCESS HELPERS ----------------------------------- #
-def kill_orphan_excels():
-    for p in psutil.process_iter(attrs=["name"]):
-        if p.info["name"] and p.info["name"].lower().startswith("excel"):
-            try:
-                p.kill()
-            except Exception:
-                pass
-
-
-def copy_template(src: str, dst_root: str, new_name: str, log: logging.Logger) -> Path:
-    src_path = Path(src)
-    if not src_path.exists():
-        raise FlowError(f"Template not found: {src}", work_completed=False)
-
-    dst_root = Path(dst_root).expanduser().resolve()
-    dst_root.mkdir(parents=True, exist_ok=True)
-    dst = dst_root / new_name
-
-    try:
-        shutil.copy2(src_path, dst)
-    except PermissionError:
-        log.warning("Destination locked; unlinking and retrying copy")
-        try:
-            dst.unlink()
-        except Exception:
-            pass
-        shutil.copy2(src_path, dst)
-
-    return dst
-
-
-def wait_ready(wb: xw.Book, log: logging.Logger):
-    start = time.time()
-    last_log = -999
-    while True:
-        try:
-            ref = wb.names[READY_NAME].refers_to
-            if ref.startswith("="):  # e.g. ="READY" or =READY
-                ref = ref[1:]
-            flag = ref.strip('"').strip()
-        except Exception:
-            flag = "<not-set>"
-
-        elapsed = int(time.time() - start)
-        if elapsed != last_log:
-            log.info("Polling flag: %s (t=%ss)", flag, elapsed)
-            last_log = elapsed
-
-        if flag == READY_OK:
-            return
-        if flag == READY_ERR:
-            raise FlowError("VBA signaled ERROR", work_completed=False)
-        if elapsed >= READY_TO:
-            raise FlowError("Timeout waiting for READY flag", work_completed=False)
-        time.sleep(POLL_SLEEP)
-
-
-def _open_excel_with_timeout(path: Path, log: logging.Logger) -> tuple[xw.App, xw.Book]:
-    log.info("Creating Excel App …")
-    app = xw.App(visible=VISIBLE_EXCEL, add_book=False)
-    app.api.DisplayFullScreen = False
-    app.api.Application.DisplayAlerts = False
-
-    log.info("Opening workbook …")
-    t0 = time.time()
-    while True:
-        try:
-            book = app.books.open(str(path))
-            return app, book
-        except Exception as e:
-            if time.time() - t0 > OPEN_TO:
-                log.error("Excel open timed out after %s s", OPEN_TO)
-                try:
-                    app.kill()
-                except Exception:
-                    pass
-                raise FlowError(f"Excel failed to open workbook: {e}", False)
-            pythoncom.PumpWaitingMessages()
-            time.sleep(0.5)
-
-
-def _run_macro_impl(wb_path: Path, args: tuple, log: logging.Logger):
-    app, wb = _open_excel_with_timeout(wb_path, log)
-    try:
-        log.info("Running macro PopulateAndRunReport …")
-        wb.macro("PopulateAndRunReport")(*args)
-        wait_ready(wb, log)
-        wb.api.Application.CalculateFull()
-        wb.save()
-        log.info("Workbook saved")
-    finally:
-        for op in (wb.close, app.kill):
-            try:
-                op()
-            except Exception:
-                pass
-
-
-def run_macro(wb_path: Path, args: tuple, log: logging.Logger):
-    exc: list[Exception] = []
-
-    def _worker():
-        try:
-            pythoncom.CoInitialize()
-            _run_macro_impl(wb_path, args, log)
-        except Exception as e:
-            exc.append(e)
-        finally:
-            try:
-                pythoncom.CoUninitialize()
-            except Exception:
-                pass
-
-    th = threading.Thread(target=_worker, daemon=True)
-    th.start()
-
-    start = time.time()
-    while th.is_alive():
-        time.sleep(0.5)
-        if time.time() - start > READY_TO:
-            log.error("Macro exceeded %s s – killing Excel", READY_TO)
-            kill_orphan_excels()
-            raise FlowError("Timeout running macro", work_completed=False)
-
-    if exc:
-        raise exc[0]
-
-
-def read_cell(wb_path: Path, col: str, row: str) -> Any:
-    app = xw.App(visible=VISIBLE_EXCEL, add_book=False)
-    app.api.DisplayFullScreen = False
-    try:
-        wb = app.books.open(str(wb_path))
-        value = wb.sheets[SCAC_VALIDATION_SHEET].range(f"{col}{row}").value
-    finally:
-        for op in (wb.close, app.kill):
-            try:
-                op()
-            except Exception:
-                pass
-    return value
-
-
-def sp_ctx(site_url: str | None = None):
-    if not (SP_USERNAME and SP_PASSWORD):
-        raise FlowError("SharePoint credentials missing", work_completed=False)
-
-    base = site_url.rstrip("/") if site_url else ROOT_SP_SITE
-    return ClientContext(base).with_credentials(
-        UserCredential(SP_USERNAME, SP_PASSWORD)
-    )
-
-
-def sp_exists(ctx, rel_url: str) -> bool:
-    try:
-        ctx.web.get_file_by_server_relative_url(rel_url).get().execute_query()
-        return True
-    except Exception:
-        return False
-
-
-def sp_upload(ctx, folder: str, fname: str, local: Path):
-    tgt = ctx.web.get_folder_by_server_relative_url(folder)
-    with local.open("rb") as f:
-        content = f.read()
-    tgt.upload_file(fname, content).execute_query()
+from .constants import LOG_DIR, RETRY_SLEEP
+from .excel_utils import (
+    copy_template,
+    kill_orphan_excels,
+    read_cell,
+    run_excel_macro,
+)
+from .exceptions import FlowError
+from .sharepoint_utils import (
+    sp_ctx,
+    sp_exists,
+    sp_upload,
+    sharepoint_file_exists,
+    sharepoint_upload,
+)
 
 
 # -------------------- ROW PROCESSOR -------------------------------------- #
+
+
 def process_row(
     row: Dict[str, Any], upload: bool, root: str, run_id: str, log: logging.Logger
 ):
@@ -248,7 +42,7 @@ def process_row(
     dst_path = copy_template(row["TOOL_TEMPLATE_FILEPATH"], root, dst_name, log)
     log.info("Template copied to %s", dst_path)
 
-    run_macro(
+    run_excel_macro(
         dst_path,
         (row["SCAC_OPP"], row["WEEK_CT"], row["PROCESSING_WEEK"]),
         log,
@@ -284,7 +78,6 @@ def process_row(
         ctx = sp_ctx(row["CLIENT_DEST_SITE"])
         site_path = urlparse(row["CLIENT_DEST_SITE"]).path
         folder_name = row["CLIENT_DEST_FOLDER_PATH"].lstrip("/")
-        # build a forward-slash server-relative URL
         folder_rel = (Path(site_path) / folder_name).as_posix()
         rel_file = f"{folder_rel}/{row['NEW_EXCEL_FILENAME']}"
 
@@ -300,6 +93,8 @@ def process_row(
 
 
 # -------------------- MAIN RUNNER ---------------------------------------- #
+
+
 def run_flow(payload: Dict[str, Any]) -> Dict[str, Any]:
     if "parameters" in payload and isinstance(payload["parameters"], dict):
         payload = payload["parameters"]
@@ -379,6 +174,8 @@ def run_flow(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # -------------------- CLI ------------------------------------------------ #
+
+
 def _cli() -> None:
     ap = argparse.ArgumentParser(description="Run FM Tool processor")
     ap.add_argument("json_file", help="Payload file path or '-' for stdin")
@@ -391,5 +188,5 @@ def _cli() -> None:
     print(json.dumps(result, indent=2))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - manual execution
     _cli()

--- a/fm_tool_core/sharepoint_utils.py
+++ b/fm_tool_core/sharepoint_utils.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .constants import ROOT_SP_SITE, SP_PASSWORD, SP_USERNAME
+from .exceptions import FlowError
+
+
+def sp_ctx(site_url: str | None = None):
+    if not (SP_USERNAME and SP_PASSWORD):
+        raise FlowError("SharePoint credentials missing", work_completed=False)
+
+    base = site_url.rstrip("/") if site_url else ROOT_SP_SITE
+    try:
+        from office365.runtime.auth.user_credential import UserCredential
+        from office365.sharepoint.client_context import ClientContext
+    except Exception as exc:  # pragma: no cover - import failure
+        raise FlowError(f"SharePoint SDK missing: {exc}", work_completed=False)
+
+    return ClientContext(base).with_credentials(
+        UserCredential(SP_USERNAME, SP_PASSWORD)
+    )
+
+
+def sp_exists(ctx, rel_url: str) -> bool:
+    try:
+        ctx.web.get_file_by_server_relative_url(rel_url).get().execute_query()
+        return True
+    except Exception:
+        return False
+
+
+def sp_upload(ctx, folder: str, fname: str, local: Path):
+    tgt = ctx.web.get_folder_by_server_relative_url(folder)
+    with local.open("rb") as f:
+        content = f.read()
+    tgt.upload_file(fname, content).execute_query()
+
+
+# Backwards compatible aliases used by tests
+sharepoint_upload = sp_upload
+sharepoint_file_exists = sp_exists
+
+__all__ = [
+    "sp_ctx",
+    "sp_exists",
+    "sp_upload",
+    "sharepoint_upload",
+    "sharepoint_file_exists",
+]


### PR DESCRIPTION
## Summary
- modularize large process file
- add constants, exceptions, Excel and SharePoint helpers
- keep API compatibility for tests

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d8cb6424883338a4b9857e2c65eea