### PR TITLE
Pass bid GUID to macro and expand tests

### DIFF
--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -243,9 +243,14 @@ def process_row(
 
     try:
         log.info("Opening workbook …")
-        run_excel_macro(
-            dst_path, (row["SCAC_OPP"], row["WEEK_CT"], row["PROCESSING_WEEK"]), log
+        macro_args = (
+            row["SCAC_OPP"],
+            row["WEEK_CT"],
+            row["PROCESSING_WEEK"],
         )
+        if bid_guid is not None:
+            macro_args += (bid_guid,)
+        run_excel_macro(dst_path, macro_args, log)
         log.info("Running macro PopulateAndRunReport …")
 
         log.info("Reading validation …")


### PR DESCRIPTION
## Summary
- Include optional BID payload when building Excel macro arguments
- Verify run_excel_macro argument length for payloads with/without BID data

## Testing
- `black --check .`
- `flake8` *(fails: command not found; pip install could not find package)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895457dcdb0833392b1213deedb7601