### PR TITLE
Skip BID row insertion when no rows fetched

### DIFF
--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -282,7 +282,12 @@ def process_row(
 
         if bid_guid and insert_bid_rows:
             rows = _fetch_bid_rows(bid_guid, log)
-            insert_bid_rows(dst_path, rows, log)
+            log.info("Fetched %d BID rows", len(rows))
+            if rows:
+                insert_bid_rows(dst_path, rows, log)
+                log.info("Inserted BID rows")
+            else:
+                log.info("No BID rows fetched – skipping insert")
 
         if upload:
             ctx = sp_ctx(row["CLIENT_DEST_SITE"])

--- a/tests/test_process_single_item.py
+++ b/tests/test_process_single_item.py
@@ -140,6 +140,33 @@ def test_run_flow_inserts_bid_rows(payload):
     assert result["Out_boolWorkcompleted"] is True
 
 
+def test_run_flow_skips_insert_when_no_rows(payload):
+    """insert_bid_rows is not called when no BID rows fetched"""
+
+    with patch(
+        "fm_tool_core.process_fm_tool.run_excel_macro",
+        return_value=_FakeWorkbook(),
+    ) as macro, patch(
+        "fm_tool_core.process_fm_tool.read_cell",
+        return_value="HUMD_VAN",
+    ), patch(
+        "fm_tool_core.process_fm_tool.sharepoint_upload"
+    ), patch(
+        "fm_tool_core.process_fm_tool.sharepoint_file_exists",
+        return_value=False,
+    ), patch(
+        "fm_tool_core.process_fm_tool._fetch_bid_rows",
+        return_value=[],
+    ), patch(
+        "fm_tool_core.process_fm_tool.insert_bid_rows"
+    ) as insert_mock, patch(
+        "fm_tool_core.process_fm_tool.write_named_cell",
+    ):
+        core.run_flow(payload)
+    insert_mock.assert_not_called()
+    macro.assert_called_once()
+
+
 def test_run_flow_without_bid_payload(payload):
     """run_excel_macro only receives three args when BID-Payload missing"""
 


### PR DESCRIPTION
## Summary
- log and insert BID rows only when _fetch_bid_rows returns data
- add unit test ensuring BID row insertion is skipped when no rows fetched

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68964e1fab48833385eaa9f65e1e92eb