### PR TITLE
Add timing logs for BID row operations

### DIFF
--- a/fm_tool_core/excel_utils.py
+++ b/fm_tool_core/excel_utils.py
@@ -225,6 +225,7 @@ def run_excel_macro(wb_path: Path, args: tuple, log: logging.Logger):
 def read_cell(wb_path: Path, col: str, row: str) -> Any:
     if xw is None:
         raise FlowError("xlwings is required", work_completed=False)
+    pythoncom.CoInitialize()
     app = xw.App(visible=VISIBLE_EXCEL, add_book=False)  # type: ignore
     app.api.DisplayFullScreen = False
     try:
@@ -236,6 +237,10 @@ def read_cell(wb_path: Path, col: str, row: str) -> Any:
                 op()
             except Exception:
                 pass
+        try:
+            pythoncom.CoUninitialize()
+        except Exception:
+            pass
 
 
 __all__ = [

--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -274,11 +274,15 @@ def process_row(
             raise FlowError("Validation failed", work_completed=False)
 
         if bid_guid and insert_bid_rows:
+            start = time.perf_counter()
             rows = _fetch_bid_rows(bid_guid, log)
-            log.info("Fetched %d BID rows", len(rows))
+            fetch_time = time.perf_counter() - start
+            log.info("Fetched %d BID rows in %.3fs", len(rows), fetch_time)
             if rows:
+                start = time.perf_counter()
                 insert_bid_rows(dst_path, rows, log)
-                log.info("Inserted BID rows")
+                ins_time = time.perf_counter() - start
+                log.info("Inserted %d BID rows in %.3fs", len(rows), ins_time)
             else:
                 log.info("No BID rows fetched – skipping insert")
 


### PR DESCRIPTION
## Summary
- Log duration and row counts for `_fetch_bid_rows` and `insert_bid_rows`
- Ensure Excel cell reader initialises and uninitialises COM
- Test BID-row fetch/insert logging using `caplog`

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6896508c437c83338715675660f99b53