### PR TITLE
Skip BID insert when no rows

### DIFF
--- a/fm_tool_core/bid_utils.py
+++ b/fm_tool_core/bid_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from itertools import chain
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -32,6 +33,14 @@ def insert_bid_rows(
     wb_path: Path, rows: Iterable[dict[str, Any]], log: logging.Logger
 ) -> None:
     """Append valid *rows* to the BID table of ``wb_path``."""
+    row_iter = iter(rows)
+    try:
+        first = next(row_iter)
+    except StopIteration:
+        log.info("No BID rows to insert")
+        return
+    rows = chain([first], row_iter)
+
     wb = openpyxl.load_workbook(wb_path, keep_vba=True)
     try:
         ws = wb["BID"]

--- a/tests/test_bid_utils.py
+++ b/tests/test_bid_utils.py
@@ -1,0 +1,23 @@
+import logging
+import sys
+import types
+
+
+def test_insert_bid_rows_early_return(monkeypatch, tmp_path, caplog):
+    called = False
+
+    def fake_load_workbook(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("load_workbook should not be called")
+
+    dummy = types.SimpleNamespace(load_workbook=fake_load_workbook)
+    monkeypatch.setitem(sys.modules, "openpyxl", dummy)
+
+    from fm_tool_core import bid_utils
+
+    log = logging.getLogger("test")
+    with caplog.at_level(logging.INFO):
+        bid_utils.insert_bid_rows(tmp_path / "wb.xlsx", [], log)
+    assert not called
+    assert "No BID rows to insert" in caplog.text


### PR DESCRIPTION
## Summary
- Return early in `insert_bid_rows` when no rows provided and log that no insert is needed
- Add tests to cover no-row scenario for `insert_bid_rows`

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6896544725c08333b373d7f0db91a5fc