### PR TITLE
Handle protected BID sheets before data insert

### DIFF
--- a/fm_tool_core/bid_utils.py
+++ b/fm_tool_core/bid_utils.py
@@ -65,6 +65,9 @@ def insert_bid_rows(
         except Exception:
             log.error("BID sheet not found in %s", wb_path)
             return
+        was_protected = bool(getattr(ws.api, "ProtectContents", False))
+        if was_protected:
+            ws.api.Unprotect()
         start = ws.api.Cells(ws.api.Rows.Count, 1).End(-4162).Row + 1
         chunk = 500
         idx = 0
@@ -74,6 +77,8 @@ def insert_bid_rows(
             ws.range(f"A{start}:M{end}").value = block
             start = end + 1
             idx += chunk
+        if was_protected:
+            ws.api.Protect()
         wb.save()
     finally:
         if wb is not None:

--- a/tests/test_bid_utils.py
+++ b/tests/test_bid_utils.py
@@ -21,3 +21,96 @@ def test_insert_bid_rows_early_return(monkeypatch, tmp_path, caplog):
         bid_utils.insert_bid_rows(tmp_path / "wb.xlsx", [], log)
     assert not called
     assert "No BID rows to insert" in caplog.text
+
+
+def test_insert_bid_rows_unprotects_and_protects(monkeypatch, tmp_path):
+    from fm_tool_core import bid_utils
+
+    calls: list[str] = []
+
+    class FakeApi:
+        def __init__(self):
+            self.ProtectContents = True
+            self.Rows = types.SimpleNamespace(Count=1)
+
+        def Unprotect(self, _password=None):
+            calls.append("unprotect")
+
+        def Protect(self, _password=None):
+            calls.append("protect")
+
+        def Cells(self, _row, _col):
+            end = lambda _dir: types.SimpleNamespace(Row=1)
+            return types.SimpleNamespace(End=end)
+
+    class FakeRange:
+        def __init__(self):
+            self._value = None
+
+        @property
+        def value(self):
+            return self._value
+
+        @value.setter
+        def value(self, val):
+            calls.append("write")
+            self._value = val
+
+    class FakeSheet:
+        def __init__(self):
+            self.api = FakeApi()
+
+        def range(self, _addr):
+            return FakeRange()
+
+    class FakeBook:
+        def __init__(self):
+            self.sheets = {"BID": FakeSheet()}
+
+        def save(self):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_open(_path):
+        return FakeBook()
+
+    class FakeBooks:
+        def open(self, path):
+            return fake_open(path)
+
+    class FakeApp:
+        def __init__(self, *args, **kwargs):
+            self.api = types.SimpleNamespace(DisplayAlerts=False)
+            self.books = FakeBooks()
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(
+        bid_utils,
+        "xw",
+        types.SimpleNamespace(App=FakeApp),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        bid_utils,
+        "pythoncom",
+        types.SimpleNamespace(
+            CoInitialize=lambda: None,
+            CoUninitialize=lambda: None,
+        ),
+        raising=False,
+    )
+
+    rows = [
+        {
+            "Lane ID": "1",
+            "Orig Zip (5 or 3)": "11111",
+            "Dest Zip (5 or 3)": "22222",
+        }
+    ]
+    log = logging.getLogger("test")
+    bid_utils.insert_bid_rows(tmp_path / "wb.xlsx", rows, log)
+    assert calls == ["unprotect", "write", "protect"]


### PR DESCRIPTION
## Summary
- unprotect the BID sheet if needed before writing new rows
- restore protection after data insertion
- add test ensuring Unprotect and Protect wrap range write

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689675417fe08333a79defbc8ff0ac7d