### PR TITLE
Add helper for ad-hoc header mappings

### DIFF
--- a/fm_tool_core/bid_utils.py
+++ b/fm_tool_core/bid_utils.py
@@ -46,10 +46,12 @@ _REQUIRED = {
     "DEST_POSTAL_CD",
 }
 
-_TARGET_SHEET = "RFP"          # ← changed from “BID”
+_TARGET_SHEET = "RFP"  # ← changed from “BID”
 
 
-def insert_bid_rows(wb_path: Path, rows: Iterable[dict[str, Any]], log: logging.Logger) -> None:
+def insert_bid_rows(
+    wb_path: Path, rows: Iterable[dict[str, Any]], log: logging.Logger
+) -> None:
     """Bulk-insert BID/RFP *rows* into the RFP sheet of *wb_path*."""
     row_iter = iter(rows)
     try:

--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -225,6 +225,47 @@ def _fetch_bid_rows(process_guid: str, log: logging.Logger) -> List[Dict[str, An
                 pass
 
 
+def _fetch_adhoc_headers(process_guid: str, log: logging.Logger) -> Dict[str, str]:
+    """Return ADHOC_INFO* labels for *process_guid*."""
+    if pyodbc is None:
+        log.info("(SQL disabled) would fetch ad-hoc headers for %s", process_guid)
+        return {}
+
+    conn = None
+    try:
+        conn = pyodbc.connect(_sql_conn_str(), timeout=10)
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT PROCESS_JSON FROM dbo.MAPPING_AGENT_PROCESSES "
+                "WHERE PROCESS_GUID = ?",
+                (process_guid,),
+            )
+            row = cur.fetchone()
+            if not row or not row[0]:
+                return {}
+            try:
+                data = json.loads(row[0])
+            except Exception as exc:
+                log.warning("Malformed PROCESS_JSON: %s", exc)
+                return {}
+            return {
+                k: v
+                for k, v in (
+                    (f"ADHOC_INFO{i}", data.get(f"ADHOC_INFO{i}")) for i in range(1, 11)
+                )
+                if isinstance(v, str)
+            }
+    except Exception as exc:
+        log.warning("Failed to fetch ad-hoc headers: %s", exc)
+        return {}
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
 # ───────────────────────────── ROW WORKER ──────────────────────────────────
 def process_row(
     row: Dict[str, Any],

--- a/tests/test_adhoc_headers.py
+++ b/tests/test_adhoc_headers.py
@@ -1,0 +1,58 @@
+import logging
+import types
+
+from fm_tool_core import process_fm_tool as mod
+
+
+def _setup_pyodbc(monkeypatch, json_str):
+    class Cur:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def execute(self, *_args, **_kwargs):
+            pass
+
+        def fetchone(self):
+            return (json_str,)
+
+    class Conn:
+        def cursor(self):
+            return Cur()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        mod,
+        "pyodbc",
+        types.SimpleNamespace(connect=lambda *a, **k: Conn()),
+    )
+    monkeypatch.setattr(mod, "_sql_conn_str", lambda: "conn")
+
+
+def test_fetch_adhoc_headers_success(monkeypatch):
+    _setup_pyodbc(monkeypatch, '{"ADHOC_INFO1": "A", "ADHOC_INFO2": "B"}')
+    log = logging.getLogger("test")
+    res = mod._fetch_adhoc_headers("guid", log)
+    assert res == {"ADHOC_INFO1": "A", "ADHOC_INFO2": "B"}
+
+
+def test_fetch_adhoc_headers_no_pyodbc(monkeypatch, caplog):
+    monkeypatch.setattr(mod, "pyodbc", None)
+    log = logging.getLogger("test")
+    with caplog.at_level(logging.INFO):
+        res = mod._fetch_adhoc_headers("guid", log)
+    assert res == {}
+    assert "SQL disabled" in caplog.text
+
+
+def test_fetch_adhoc_headers_bad_json(monkeypatch, caplog):
+    _setup_pyodbc(monkeypatch, "not-json")
+    log = logging.getLogger("test")
+    with caplog.at_level(logging.WARNING):
+        res = mod._fetch_adhoc_headers("guid", log)
+    assert res == {}
+    assert "Malformed PROCESS_JSON" in caplog.text


### PR DESCRIPTION
## Summary
- add `_fetch_adhoc_headers` to query PROCESS_JSON and map ADHOC_INFO fields
- test helper for success, missing pyodbc, and malformed JSON
- align bid util tests with RFP sheet name

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6897c9f4d5dc8333b3661c87c7f1f3b8