### PR TITLE
feat: support custom RFP header labels

### DIFF
--- a/fm_tool_core/bid_utils.py
+++ b/fm_tool_core/bid_utils.py
@@ -50,9 +50,17 @@ _TARGET_SHEET = "RFP"  # ← changed from “BID”
 
 
 def insert_bid_rows(
-    wb_path: Path, rows: Iterable[dict[str, Any]], log: logging.Logger
+    wb_path: Path,
+    rows: Iterable[dict[str, Any]],
+    log: logging.Logger,
+    adhoc_headers: dict[str, str] | None = None,
 ) -> None:
-    """Bulk-insert BID/RFP *rows* into the RFP sheet of *wb_path*."""
+    """
+    Bulk-insert BID/RFP *rows* into the RFP sheet of *wb_path*.
+
+    If *adhoc_headers* is provided, header labels matching its keys are
+    replaced with the corresponding values before inserting any data rows.
+    """
     row_iter = iter(rows)
     try:
         first = next(row_iter)
@@ -86,6 +94,12 @@ def insert_bid_rows(
         except Exception:
             log.error("%s sheet not found in %s", _TARGET_SHEET, wb_path)
             return
+
+        if adhoc_headers:
+            header_rng = ws.range((1, 1)).resize(1, len(_COLUMNS))
+            values = header_rng.value
+            if isinstance(values, list):
+                header_rng.value = [adhoc_headers.get(str(v), v) for v in values]
 
         # First empty row in column A
         start_row = ws.api.Cells(ws.api.Rows.Count, 1).End(-4162).Row + 1

--- a/tests/test_bid_utils.py
+++ b/tests/test_bid_utils.py
@@ -110,3 +110,119 @@ def test_insert_bid_rows_writes_rows(monkeypatch, tmp_path):
     log = logging.getLogger("test")
     bid_utils.insert_bid_rows(tmp_path / "wb.xlsx", rows, log)
     assert calls == ["write"]
+
+
+def test_insert_bid_rows_custom_headers(monkeypatch, tmp_path):
+    from fm_tool_core import bid_utils
+
+    calls: list[str] = []
+
+    class FakeApi:
+        def __init__(self):
+            self.Rows = types.SimpleNamespace(Count=1)
+
+        def Cells(self, _row, _col):
+            end = lambda _dir: types.SimpleNamespace(Row=1)
+            return types.SimpleNamespace(End=end)
+
+    class FakeHeaderRange:
+        def __init__(self, sheet):
+            self.sheet = sheet
+
+        def resize(self, _r, _c):
+            return self
+
+        @property
+        def value(self):
+            return self.sheet.headers
+
+        @value.setter
+        def value(self, val):
+            self.sheet.headers = val
+
+    class FakeDataRange:
+        def __init__(self):
+            self._value = None
+
+        def resize(self, _r, _c):
+            return self
+
+        @property
+        def value(self):
+            return self._value
+
+        @value.setter
+        def value(self, val):
+            calls.append("write")
+            self._value = val
+
+    class FakeSheet:
+        def __init__(self):
+            self.api = FakeApi()
+            self.headers = bid_utils._COLUMNS.copy()
+
+        def range(self, addr):
+            if addr == (1, 1):
+                return FakeHeaderRange(self)
+            return FakeDataRange()
+
+    sheet = FakeSheet()
+
+    class FakeBook:
+        def __init__(self):
+            self.sheets = {"RFP": sheet}
+
+        def save(self):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_open(_path):
+        return FakeBook()
+
+    class FakeBooks:
+        def open(self, path):
+            return fake_open(path)
+
+    class FakeApp:
+        def __init__(self, *args, **kwargs):
+            self.api = types.SimpleNamespace(DisplayAlerts=False)
+            self.books = FakeBooks()
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(
+        bid_utils,
+        "xw",
+        types.SimpleNamespace(App=FakeApp),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        bid_utils,
+        "pythoncom",
+        types.SimpleNamespace(
+            CoInitialize=lambda: None,
+            CoUninitialize=lambda: None,
+        ),
+        raising=False,
+    )
+
+    rows = [
+        {
+            "LANE_ID": "1",
+            "ORIG_POSTAL_CD": "11111",
+            "DEST_POSTAL_CD": "22222",
+        }
+    ]
+    log = logging.getLogger("test")
+    bid_utils.insert_bid_rows(
+        tmp_path / "wb.xlsx",
+        rows,
+        log,
+        adhoc_headers={"ADHOC_INFO1": "X1", "ADHOC_INFO3": "X3"},
+    )
+    assert calls == ["write"]
+    assert sheet.headers[13] == "X1"
+    assert sheet.headers[15] == "X3"


### PR DESCRIPTION
## Summary
- allow `insert_bid_rows` to relabel RFP headers via optional `adhoc_headers`
- cover header relabeling with unit test

## Testing
- `black --check fm_tool_core/bid_utils.py tests/test_bid_utils.py`
- `flake8` *(fails: command not found and install blocked)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6897cda7be54833387d869daf789e9a2