### PR TITLE
Fetch ad-hoc headers for BID row inserts

### DIFF
--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -326,9 +326,10 @@ def process_row(
             rows = _fetch_bid_rows(bid_guid, log)
             fetch_time = time.perf_counter() - start
             log.info("Fetched %d BID rows in %.3fs", len(rows), fetch_time)
+            headers = _fetch_adhoc_headers(bid_guid, log)
             if rows:
                 start = time.perf_counter()
-                insert_bid_rows(dst_path, rows, log)
+                insert_bid_rows(dst_path, rows, log, headers)
                 ins_time = time.perf_counter() - start
                 log.info(
                     "Batch inserted %d BID rows in %.3fs",

--- a/tests/test_process_single_item.py
+++ b/tests/test_process_single_item.py
@@ -84,6 +84,9 @@ def test_run_flow_success(payload):
         "fm_tool_core.process_fm_tool._fetch_bid_rows",
         return_value=bid_rows,
     ), patch(
+        "fm_tool_core.process_fm_tool._fetch_adhoc_headers",
+        return_value={},
+    ), patch(
         "fm_tool_core.process_fm_tool.insert_bid_rows",
     ):
         result = core.run_flow(payload)
@@ -116,11 +119,15 @@ def test_run_flow_inserts_bid_rows(payload, caplog):
         "fm_tool_core.process_fm_tool._fetch_bid_rows",
         return_value=bid_rows,
     ), patch(
+        "fm_tool_core.process_fm_tool._fetch_adhoc_headers",
+        return_value={"ADHOC_INFO1": "X1"},
+    ), patch(
         "fm_tool_core.process_fm_tool.insert_bid_rows"
     ) as insert_mock:
         with caplog.at_level(logging.INFO):
             result = core.run_flow(payload)
     insert_mock.assert_called_once()
+    assert insert_mock.call_args[0][3] == {"ADHOC_INFO1": "X1"}
     macro.assert_called_once()
     assert len(macro.call_args[0][1]) == 4
     assert any("Fetched 1 BID rows in" in rec.message for rec in caplog.records)
@@ -145,6 +152,9 @@ def test_run_flow_skips_insert_when_no_rows(payload, caplog):
     ), patch(
         "fm_tool_core.process_fm_tool._fetch_bid_rows",
         return_value=[],
+    ), patch(
+        "fm_tool_core.process_fm_tool._fetch_adhoc_headers",
+        return_value={},
     ), patch(
         "fm_tool_core.process_fm_tool.insert_bid_rows"
     ) as insert_mock:


### PR DESCRIPTION
## Summary
- After retrieving BID data, also fetch ad-hoc header labels and pass them into `insert_bid_rows`
- Cover BID header behaviour in run_flow tests

## Testing
- `python -m black --check .`
- `flake8` *(fails: command not found, installation blocked)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6897cf3484888333b229e79bf83e7a0a