### PR TITLE
Handle nested header ranges for adhoc replacement

### DIFF
--- a/fm_tool_core/bid_utils.py
+++ b/fm_tool_core/bid_utils.py
@@ -99,7 +99,10 @@ def insert_bid_rows(
             header_rng = ws.range((1, 1)).resize(1, len(_COLUMNS))
             values = header_rng.value
             if isinstance(values, list):
-                header_rng.value = [adhoc_headers.get(str(v), v) for v in values]
+                nested = bool(values and isinstance(values[0], list))
+                headers = values[0] if nested else values
+                headers = [adhoc_headers.get(str(v), v) for v in headers]
+                header_rng.value = [headers] if nested else headers
 
         # First empty row in column A
         start_row = ws.api.Cells(ws.api.Rows.Count, 1).End(-4162).Row + 1
@@ -109,7 +112,12 @@ def insert_bid_rows(
         # One-shot write
         ws.range((start_row, 1)).resize(n_rows, n_cols).value = data
         wb.save()
-        log.info("Wrote %d rows × %d cols to %s sheet", n_rows, n_cols, _TARGET_SHEET)
+        log.info(
+            "Wrote %d rows × %d cols to %s sheet",
+            n_rows,
+            n_cols,
+            _TARGET_SHEET,
+        )
     finally:
         if wb is not None:
             try:

--- a/tests/test_bid_utils.py
+++ b/tests/test_bid_utils.py
@@ -140,11 +140,12 @@ def test_insert_bid_rows_custom_headers(monkeypatch, tmp_path):
 
         @property
         def value(self):
-            return self.sheet.headers
+            return [self.sheet.headers]
 
         @value.setter
         def value(self, val):
-            self.sheet.headers = val
+            assert isinstance(val, list) and isinstance(val[0], list)
+            self.sheet.headers = val[0]
 
     class FakeDataRange:
         def __init__(self):


### PR DESCRIPTION
## Summary
- correctly handle xlwings header ranges that return nested lists when applying adhoc headers
- extend unit test to mimic nested header range structure

## Testing
- `black --check fm_tool_core/bid_utils.py tests/test_bid_utils.py`
- `flake8` *(fails: command not found; package installation blocked by network)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6897d7048fdc8333aa4f2c6f12051b3b