### PR TITLE
Handle nested header ranges in insert_bid_rows

### DIFF
--- a/fm_tool_core/bid_utils.py
+++ b/fm_tool_core/bid_utils.py
@@ -99,7 +99,10 @@ def insert_bid_rows(
             header_rng = ws.range((1, 1)).resize(1, len(_COLUMNS))
             values = header_rng.value
             if isinstance(values, list):
-                header_rng.value = [adhoc_headers.get(str(v), v) for v in values]
+                nested = bool(values and isinstance(values[0], list))
+                row = values[0] if nested else values
+                mapped_row = [adhoc_headers.get(str(v), v) for v in row]
+                header_rng.value = [mapped_row] if nested else mapped_row
 
         # First empty row in column A
         start_row = ws.api.Cells(ws.api.Rows.Count, 1).End(-4162).Row + 1

--- a/tests/test_bid_utils.py
+++ b/tests/test_bid_utils.py
@@ -140,11 +140,11 @@ def test_insert_bid_rows_custom_headers(monkeypatch, tmp_path):
 
         @property
         def value(self):
-            return self.sheet.headers
+            return [self.sheet.headers]
 
         @value.setter
         def value(self, val):
-            self.sheet.headers = val
+            self.sheet.headers = val[0] if val and isinstance(val[0], list) else val
 
     class FakeDataRange:
         def __init__(self):


### PR DESCRIPTION
## Summary
- support mapping custom headers when xlwings returns nested lists
- adjust tests to mimic nested header range structure

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68990c264be483339d071993ade8c8c4