### PR TITLE
Normalize adhoc header handling

### DIFF
--- a/fm_tool_core/bid_utils.py
+++ b/fm_tool_core/bid_utils.py
@@ -107,7 +107,11 @@ def insert_bid_rows(
                     and not isinstance(outer[0], str)
                 )
                 row = list(outer[0]) if nested else outer
-                mapped_row = [adhoc_headers.get(str(v), v) for v in row]
+                norm = {str(k).strip().upper(): v for k, v in adhoc_headers.items()}
+                mapped_row = []
+                for v in row:
+                    key = str(v).strip().upper()
+                    mapped_row.append(norm.get(key, v))
                 header_rng.value = [mapped_row] if nested else mapped_row
 
         # First empty row in column A

--- a/tests/test_bid_utils.py
+++ b/tests/test_bid_utils.py
@@ -166,6 +166,8 @@ def test_insert_bid_rows_custom_headers(monkeypatch, tmp_path):
         def __init__(self):
             self.api = FakeApi()
             self.headers = bid_utils._COLUMNS.copy()
+            self.headers[13] = " adhoc_info1 "
+            self.headers[15] = "AdHoC_Info3  "
 
         def range(self, addr):
             if addr == (1, 1):
@@ -227,7 +229,7 @@ def test_insert_bid_rows_custom_headers(monkeypatch, tmp_path):
         wb_path,
         rows,
         log,
-        adhoc_headers={"ADHOC_INFO1": "X1", "ADHOC_INFO3": "X3"},
+        adhoc_headers={" AdHoC_inFo1 ": "X1", "adhoc_info3": "X3"},
     )
     assert calls == ["write"]
     assert sheet.headers[13] == "X1"

--- a/tests/test_process_single_item.py
+++ b/tests/test_process_single_item.py
@@ -120,14 +120,14 @@ def test_run_flow_inserts_bid_rows(payload, caplog):
         return_value=bid_rows,
     ), patch(
         "fm_tool_core.process_fm_tool._fetch_adhoc_headers",
-        return_value={"ADHOC_INFO1": "X1"},
+        return_value={" AdHoc_Info1 ": "X1"},
     ), patch(
         "fm_tool_core.process_fm_tool.insert_bid_rows"
     ) as insert_mock:
         with caplog.at_level(logging.INFO):
             result = core.run_flow(payload)
     insert_mock.assert_called_once()
-    assert insert_mock.call_args[0][3] == {"ADHOC_INFO1": "X1"}
+    assert insert_mock.call_args[0][3] == {" AdHoc_Info1 ": "X1"}
     macro.assert_called_once()
     assert len(macro.call_args[0][1]) == 4
     assert any("Fetched 1 BID rows in" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Ensure `insert_bid_rows` normalizes worksheet headers and mapping keys when renaming columns
- Extend tests to use mixed-case or padded adhoc header names

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899ff75cae88333bc8c302d08bf16f1