### PR TITLE
chore: disable python ci workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,10 +1,11 @@
 name: Python CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+# Disabled workflow triggers
+# on:
+#   push:
+#     branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- disable python ci workflow triggers so actions do not run automatically

## Testing
- `black --check .`
- `flake8 .` *(fails: command not found)*
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement pytest==8.2.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a386cba8483339e38b31ae3930f05