### PR TITLE
Fetch customer IDs for home sheet population

### DIFF
--- a/fm_tool_core/excel_utils.py
+++ b/fm_tool_core/excel_utils.py
@@ -7,7 +7,7 @@ import shutil
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 from .constants import (
     OPEN_TO,
@@ -223,7 +223,10 @@ def run_excel_macro(wb_path: Path, args: tuple, log: logging.Logger):
 
 
 def write_home_fields(
-    wb_path: Path, process_guid: str | None, customer_name: str | None
+    wb_path: Path,
+    process_guid: str | None,
+    customer_name: str | None,
+    customer_ids: Sequence[str] | None = None,
 ) -> None:
     """Write basic HOME sheet fields to *wb_path*."""
     if xw is None:
@@ -237,6 +240,10 @@ def write_home_fields(
         ws = wb.sheets["HOME"]
         ws.range("BID").value = process_guid
         ws.range("D8").value = customer_name
+        if customer_ids:
+            cells = ["D10", "E10", "F10", "G10", "H10"]
+            for cell, cid in zip(cells, customer_ids):
+                ws.range(cell).value = cid
         wb.save()
     finally:
         if wb is not None:

--- a/tests/test_excel_utils.py
+++ b/tests/test_excel_utils.py
@@ -32,15 +32,18 @@ def test_write_home_fields(monkeypatch, tmp_path):
     pc = SimpleNamespace(CoInitialize=MagicMock(), CoUninitialize=MagicMock())
     monkeypatch.setattr(excel_utils, "pythoncom", pc)
 
-    bid_rng = SimpleNamespace(value=None)
-    d8_rng = SimpleNamespace(value=None)
+    cells = {
+        "BID": SimpleNamespace(value=None),
+        "D8": SimpleNamespace(value=None),
+        "D10": SimpleNamespace(value=None),
+        "E10": SimpleNamespace(value=None),
+        "F10": SimpleNamespace(value=None),
+        "G10": SimpleNamespace(value=None),
+        "H10": SimpleNamespace(value=None),
+    }
 
     def range_side_effect(addr):
-        if addr == "BID":
-            return bid_rng
-        if addr == "D8":
-            return d8_rng
-        raise AssertionError
+        return cells[addr]
 
     sheet = SimpleNamespace(range=MagicMock(side_effect=range_side_effect))
     wb = SimpleNamespace(sheets={"HOME": sheet}, save=MagicMock(), close=MagicMock())
@@ -53,9 +56,15 @@ def test_write_home_fields(monkeypatch, tmp_path):
     xw_mock = SimpleNamespace(App=MagicMock(return_value=app))
     monkeypatch.setattr(excel_utils, "xw", xw_mock)
 
-    excel_utils.write_home_fields(tmp_path / "wb.xlsx", "pg", "cust")
-    assert bid_rng.value == "pg"
-    assert d8_rng.value == "cust"
+    ids = ["c1", "c2", "c3", "c4", "c5"]
+    excel_utils.write_home_fields(tmp_path / "wb.xlsx", "pg", "cust", ids)
+    assert cells["BID"].value == "pg"
+    assert cells["D8"].value == "cust"
+    assert cells["D10"].value == "c1"
+    assert cells["E10"].value == "c2"
+    assert cells["F10"].value == "c3"
+    assert cells["G10"].value == "c4"
+    assert cells["H10"].value == "c5"
     wb.save.assert_called_once_with()
     wb.close.assert_called_once_with()
     app.kill.assert_called_once_with()


### PR DESCRIPTION
## Summary
- query up to five customer IDs for a BID's process GUID
- allow write_home_fields to fill D10–H10 with customer IDs
- ensure process_row fetches IDs and passes them to workbook creation
- extend tests for customer ID handling

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a38840a008333837d77b5cbc095c5