### PR TITLE
Refactor ad-hoc header updates into helper

### DIFF
--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -49,9 +49,10 @@ except ImportError as _e:  # pragma: no cover
     logging.warning("pyodbc missing – SQL disabled (%s)", _e)
 
 try:
-    from .bid_utils import _COLUMNS
+    from .bid_utils import _COLUMNS, update_adhoc_headers
 except Exception as _e:  # pragma: no cover
     _COLUMNS = []  # type: ignore
+    update_adhoc_headers = lambda *a, **k: None  # type: ignore
     logging.basicConfig(level=logging.WARNING)
     logging.warning("BID utils unavailable: %s", _e)
 from .constants import LOG_DIR, RETRY_SLEEP
@@ -327,6 +328,9 @@ def process_row(
     if bid_guid is not None:
         cust_ids = _fetch_customer_ids(bid_guid, log)
     write_home_fields(dst_path, bid_guid, row.get("CUSTOMER_NAME"), cust_ids)
+    if bid_guid is not None:
+        adhoc = _fetch_adhoc_headers(bid_guid, log)
+        update_adhoc_headers(dst_path, adhoc, log)
 
     log.info("Waiting for CPU to drop")
     wait_for_cpu(log=log)

--- a/tests/test_process_single_item.py
+++ b/tests/test_process_single_item.py
@@ -83,7 +83,12 @@ def test_run_flow_success(payload):
         return_value=["i1", "i2"],
     ) as cid_mock, patch(
         "fm_tool_core.process_fm_tool.write_home_fields",
-    ) as write_mock:
+    ) as write_mock, patch(
+        "fm_tool_core.process_fm_tool._fetch_adhoc_headers",
+        return_value={"ADHOC_INFO1": "A"},
+    ) as adhoc_mock, patch(
+        "fm_tool_core.process_fm_tool.update_adhoc_headers",
+    ) as upd_mock:
         result = core.run_flow(payload)
     macro.assert_called_once()
     args_tuple = macro.call_args[0][1]
@@ -94,6 +99,8 @@ def test_run_flow_success(payload):
     write_mock.assert_called_once_with(
         ANY, payload["BID-Payload"], "ACME", ["i1", "i2"]
     )
+    adhoc_mock.assert_called_once_with(payload["BID-Payload"], ANY)
+    upd_mock.assert_called_once_with(ANY, {"ADHOC_INFO1": "A"}, ANY)
     assert result["Out_boolWorkcompleted"] is True
     assert result["Out_strWorkExceptionMessage"] == ""
 
@@ -117,10 +124,16 @@ def test_run_flow_without_bid_payload(payload):
         "fm_tool_core.process_fm_tool._fetch_customer_ids"
     ) as cid_mock, patch(
         "fm_tool_core.process_fm_tool.write_home_fields",
-    ) as write_mock:
+    ) as write_mock, patch(
+        "fm_tool_core.process_fm_tool._fetch_adhoc_headers",
+    ) as adhoc_mock, patch(
+        "fm_tool_core.process_fm_tool.update_adhoc_headers",
+    ) as upd_mock:
         result = core.run_flow(payload)
     macro.assert_called_once()
     assert len(macro.call_args[0][1]) == 3
     write_mock.assert_called_once_with(ANY, None, "ACME", None)
     cid_mock.assert_not_called()
+    adhoc_mock.assert_not_called()
+    upd_mock.assert_not_called()
     assert result["Out_boolWorkcompleted"] is True


### PR DESCRIPTION
## Summary
- Extract header replacement into `update_adhoc_headers` and reuse in `insert_bid_rows`
- Call `_fetch_adhoc_headers` and `update_adhoc_headers` in `process_row`
- Add tests for new helper and process flow

## Testing
- `black --check .`
- `flake8` *(fails: command not found, install attempt blocked)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a3d0eba2883338371507a81a72d31