### PR TITLE
Log ad-hoc headers

### DIFF
--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -262,7 +262,7 @@ def _fetch_adhoc_headers(process_guid: str, log: logging.Logger) -> Dict[str, st
                 )
                 if isinstance(v, str)
             }
-            log.debug("Fetched custom headers: %s", headers)
+            log.info("Fetched custom headers: %s", headers)
             return headers
     except Exception as exc:
         log.warning("Failed to fetch ad-hoc headers: %s", exc)
@@ -332,6 +332,10 @@ def process_row(
     write_home_fields(dst_path, bid_guid, row.get("CUSTOMER_NAME"), cust_ids)
     if bid_guid is not None:
         adhoc = _fetch_adhoc_headers(bid_guid, log)
+        if adhoc:
+            log.info("Applying ad-hoc headers: %s", adhoc)
+        else:
+            log.info("No ad-hoc headers found")
         update_adhoc_headers(dst_path, adhoc, log)
 
     log.info("Waiting for CPU to drop")

--- a/tests/test_adhoc_headers.py
+++ b/tests/test_adhoc_headers.py
@@ -33,11 +33,13 @@ def _setup_pyodbc(monkeypatch, json_str):
     monkeypatch.setattr(mod, "_sql_conn_str", lambda: "conn")
 
 
-def test_fetch_adhoc_headers_success(monkeypatch):
+def test_fetch_adhoc_headers_success(monkeypatch, caplog):
     _setup_pyodbc(monkeypatch, '{"ADHOC_INFO1": "A", "ADHOC_INFO2": "B"}')
     log = logging.getLogger("test")
-    res = mod._fetch_adhoc_headers("guid", log)
+    with caplog.at_level(logging.INFO):
+        res = mod._fetch_adhoc_headers("guid", log)
     assert res == {"ADHOC_INFO1": "A", "ADHOC_INFO2": "B"}
+    assert "Fetched custom headers" in caplog.text
 
 
 def test_fetch_adhoc_headers_no_pyodbc(monkeypatch, caplog):

--- a/tests/test_process_single_item.py
+++ b/tests/test_process_single_item.py
@@ -5,6 +5,7 @@ Mocks heavy external dependencies (Excel & SharePoint) so we can assert that:
   * Validation logic branches correctly
 """
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import ANY, patch
 
@@ -63,9 +64,9 @@ def payload(tmp_path):
     }
 
 
-def test_run_flow_success(payload):
+def test_run_flow_success(payload, caplog):
     """All validations pass -> Out_boolWorkcompleted=True"""
-    with patch(
+    with caplog.at_level(logging.INFO, logger="fm_tool"), patch(
         "fm_tool_core.process_fm_tool.run_excel_macro",
         return_value=_FakeWorkbook(),
     ) as macro, patch(
@@ -101,6 +102,7 @@ def test_run_flow_success(payload):
     )
     adhoc_mock.assert_called_once_with(payload["BID-Payload"], ANY)
     upd_mock.assert_called_once_with(ANY, {"ADHOC_INFO1": "A"}, ANY)
+    assert "Applying ad-hoc headers" in caplog.text
     assert result["Out_boolWorkcompleted"] is True
     assert result["Out_strWorkExceptionMessage"] == ""
 


### PR DESCRIPTION
## Summary
- log retrieved ad-hoc headers at info level
- note when ad-hoc headers are applied or missing during row processing
- update tests for new info-level logging

## Testing
- `black --check .`
- `flake8` *(missing: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a6c2c33c883339ae80f608a09d3c2