### PR TITLE
Support nested adhoc headers

### DIFF
--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -255,12 +255,13 @@ def _fetch_adhoc_headers(process_guid: str, log: logging.Logger) -> Dict[str, st
             except Exception as exc:
                 log.warning("Malformed PROCESS_JSON: %s", exc)
                 return {}
+            raw = data.get("adhoc_headers")
+            if not isinstance(raw, dict) or not raw:
+                raw = data
             headers = {
                 k: v
-                for k, v in (
-                    (f"ADHOC_INFO{i}", data.get(f"ADHOC_INFO{i}")) for i in range(1, 11)
-                )
-                if isinstance(v, str)
+                for k, v in raw.items()
+                if k.startswith("ADHOC_INFO") and isinstance(v, str)
             }
             log.info("Fetched custom headers: %s", headers)
             return headers

--- a/tests/test_adhoc_headers.py
+++ b/tests/test_adhoc_headers.py
@@ -34,7 +34,18 @@ def _setup_pyodbc(monkeypatch, json_str):
 
 
 def test_fetch_adhoc_headers_success(monkeypatch, caplog):
-    _setup_pyodbc(monkeypatch, '{"ADHOC_INFO1": "A", "ADHOC_INFO2": "B"}')
+    json_str = '{"adhoc_headers": {"ADHOC_INFO1": "Origin (Live/Drop)"}}'
+    _setup_pyodbc(monkeypatch, json_str)
+    log = logging.getLogger("test")
+    with caplog.at_level(logging.INFO):
+        res = mod._fetch_adhoc_headers("guid", log)
+    assert res == {"ADHOC_INFO1": "Origin (Live/Drop)"}
+    assert "Fetched custom headers" in caplog.text
+
+
+def test_fetch_adhoc_headers_legacy(monkeypatch, caplog):
+    json_str = '{"ADHOC_INFO1": "A", "ADHOC_INFO2": "B"}'
+    _setup_pyodbc(monkeypatch, json_str)
     log = logging.getLogger("test")
     with caplog.at_level(logging.INFO):
         res = mod._fetch_adhoc_headers("guid", log)

--- a/tests/test_process_single_item.py
+++ b/tests/test_process_single_item.py
@@ -86,7 +86,7 @@ def test_run_flow_success(payload, caplog):
         "fm_tool_core.process_fm_tool.write_home_fields",
     ) as write_mock, patch(
         "fm_tool_core.process_fm_tool._fetch_adhoc_headers",
-        return_value={"ADHOC_INFO1": "A"},
+        return_value={"ADHOC_INFO1": "Origin (Live/Drop)"},
     ) as adhoc_mock, patch(
         "fm_tool_core.process_fm_tool.update_adhoc_headers",
     ) as upd_mock:
@@ -102,10 +102,14 @@ def test_run_flow_success(payload, caplog):
         payload["BID-Payload"],
         "ACME",
         ["i1", "i2"],
-        {"ADHOC_INFO1": "A"},
+        {"ADHOC_INFO1": "Origin (Live/Drop)"},
     )
     adhoc_mock.assert_called_once_with(payload["BID-Payload"], ANY)
-    upd_mock.assert_called_once_with(ANY, {"ADHOC_INFO1": "A"}, ANY)
+    upd_mock.assert_called_once_with(
+        ANY,
+        {"ADHOC_INFO1": "Origin (Live/Drop)"},
+        ANY,
+    )
     assert "Applying ad-hoc headers" in caplog.text
     assert result["Out_boolWorkcompleted"] is True
     assert result["Out_strWorkExceptionMessage"] == ""


### PR DESCRIPTION
## Summary
- Support nested `adhoc_headers` JSON structure with legacy fallback
- Cover new and legacy layouts in `_fetch_adhoc_headers` tests
- Align single-item processing test with updated header format

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b5f9671e483338d920d56c277b493