### PR TITLE
Improve SharePoint upload error handling

### DIFF
--- a/tests/test_sharepoint_utils.py
+++ b/tests/test_sharepoint_utils.py
@@ -1,0 +1,24 @@
+import pytest
+from unittest.mock import MagicMock
+
+from fm_tool_core.exceptions import FlowError
+from fm_tool_core import sharepoint_utils
+
+
+def _ctx_with_exc(exc):
+    ctx = MagicMock()
+    tgt = MagicMock()
+    ctx.web.get_folder_by_server_relative_url.return_value = tgt
+    upload = tgt.upload_file.return_value
+    upload.execute_query.side_effect = exc
+    return ctx
+
+
+def test_sp_upload_client_request_exception(tmp_path):
+    local = tmp_path / "f.txt"
+    local.write_text("data")
+    ctx = _ctx_with_exc(sharepoint_utils.ClientRequestException("msg", 500, "err"))
+    with pytest.raises(FlowError) as exc:
+        sharepoint_utils.sp_upload(ctx, "/folder", "f.txt", local)
+    assert not exc.value.work_completed
+    assert "SharePoint upload failed" in str(exc.value)


### PR DESCRIPTION
## Summary
- Wrap SharePoint upload in try/except and raise FlowError with the original error when upload fails
- Add regression test for SharePoint upload error handling

## Testing
- `black --check fm_tool_core/sharepoint_utils.py tests/test_sharepoint_utils.py`
- `flake8 fm_tool_core/sharepoint_utils.py tests/test_sharepoint_utils.py` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ca58c4cc08333aa39db0c524b114d