### PR TITLE
Handle last process_row error on retry exhaustion

### DIFF
--- a/tests/test_process_single_item.py
+++ b/tests/test_process_single_item.py
@@ -187,3 +187,17 @@ def test_upload_strips_path_from_filename(payload):
     rel_arg = exists_mock.call_args[0][1]
     assert rel_arg.endswith("/dummy.xlsm")
     assert result["Out_boolWorkcompleted"] is True
+
+
+def test_run_flow_raises_last_error_message(payload):
+    """Final error message includes the last process_row failure"""
+
+    payload["item/In_intMaxRetry"] = 2
+    with patch(
+        "fm_tool_core.process_fm_tool.process_row",
+        side_effect=[RuntimeError("first"), RuntimeError("second")],
+    ), patch("fm_tool_core.process_fm_tool.time.sleep"):
+        result = core.run_flow(payload)
+    assert result["Out_boolWorkcompleted"] is False
+    msg = result["Out_strWorkExceptionMessage"]
+    assert "second" in msg and "first" not in msg


### PR DESCRIPTION
## Summary
- re-raise process_row failures for visibility
- when retries are exhausted, raise FlowError with last error message
- test retry error propagation

## Testing
- `black --check .`
- `flake8` *(failed: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ca5a64fac8333b14c7fdbde9ca44c