### PR TITLE
Handle missing BID range in Excel utils

### DIFF
--- a/fm_tool_core/excel_utils.py
+++ b/fm_tool_core/excel_utils.py
@@ -239,7 +239,11 @@ def write_home_fields(
     try:
         wb = app.books.open(str(wb_path))
         ws = wb.sheets["HOME"]
-        ws.range("BID").value = process_guid
+        if process_guid is not None:
+            try:
+                ws.range("BID").value = process_guid
+            except Exception:
+                logging.debug("BID range missing", exc_info=True)
         # Populate the entire merged customer name range to preserve validation
         ws.range("D8:H8").value = customer_name
         if customer_ids:

--- a/tests/test_excel_utils.py
+++ b/tests/test_excel_utils.py
@@ -101,6 +101,56 @@ def test_write_home_fields(monkeypatch, tmp_path):
     pc.CoUninitialize.assert_called_once_with()
 
 
+def test_write_home_fields_missing_bid(monkeypatch, tmp_path):
+    pc = SimpleNamespace(CoInitialize=MagicMock(), CoUninitialize=MagicMock())
+    monkeypatch.setattr(excel_utils, "pythoncom", pc)
+
+    cust_range = SimpleNamespace(value=None)
+    cust_range.api = SimpleNamespace(Validation=object())
+
+    cells = {
+        "D8:H8": cust_range,
+        "D10": SimpleNamespace(value=None),
+        "E10": SimpleNamespace(value=None),
+        "F10": SimpleNamespace(value=None),
+        "G10": SimpleNamespace(value=None),
+        "H10": SimpleNamespace(value=None),
+    }
+    for i in range(10):
+        cells[f"AR{36 + i}"] = SimpleNamespace(value=None)
+
+    def range_side_effect(addr):
+        if addr not in cells:
+            raise KeyError(addr)
+        return cells[addr]
+
+    sheet = SimpleNamespace(range=MagicMock(side_effect=range_side_effect))
+    wb = SimpleNamespace(sheets={"HOME": sheet}, save=MagicMock(), close=MagicMock())
+    app = SimpleNamespace(
+        api=SimpleNamespace(),
+        books=SimpleNamespace(open=MagicMock(return_value=wb)),
+        kill=MagicMock(),
+    )
+
+    monkeypatch.setattr(
+        excel_utils,
+        "xw",
+        SimpleNamespace(App=MagicMock(return_value=app)),
+    )
+
+    ids = ["c1", "c2", "c3", "c4", "c5"]
+    excel_utils.write_home_fields(tmp_path / "wb.xlsx", "pg", "cust", ids, None)
+    assert "BID" not in cells
+    assert cells["D8:H8"].value == "cust"
+    assert cells["D10"].value == "c1"
+    assert cells["H10"].value == "c5"
+    wb.save.assert_called_once_with()
+    wb.close.assert_called_once_with()
+    app.kill.assert_called_once_with()
+    pc.CoInitialize.assert_called_once_with()
+    pc.CoUninitialize.assert_called_once_with()
+
+
 def test_write_home_fields_no_headers_blank(monkeypatch, tmp_path):
     pc = SimpleNamespace(CoInitialize=MagicMock(), CoUninitialize=MagicMock())
     monkeypatch.setattr(excel_utils, "pythoncom", pc)


### PR DESCRIPTION
## Summary
- skip writing BID when no process guid and ignore missing BID range
- add unit test for BID range absence

## Testing
- `black --check .`
- `flake8` *(fails: command not found, installation blocked)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a49b2fc2c88333baaf1243b5975243