### PR TITLE
Ignore BID utilities for NIT runs

### DIFF
--- a/fm_tool_core/process_fm_tool.py
+++ b/fm_tool_core/process_fm_tool.py
@@ -437,6 +437,8 @@ def run_flow(payload: Dict[str, Any]) -> Dict[str, Any]:
     scac = op_code.split("_", 1)[0].upper()
     payload_type = _detect_payload_type(rows)  # 'PIT' or 'NIT'
     log.info("Detected payload type: %s", payload_type)
+    if payload_type == "NIT":
+        bid_guid = None
 
     # BEGIN status (single proc)
     _update_status(scac, f"{payload_type}-BEGIN", log)


### PR DESCRIPTION
## Summary
- Skip BID utilities when processing NIT payloads
- Test that NIT flows bypass BID helpers and PIT flows still use them

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4ba32220c8333ae661a1bd02b9308