### PR TITLE
feat: add BID webhook notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
 python -m fm_tool_core.process_fm_tool payload.json
+```
+
+## 📡 BID Webhook
+
+Set `BID_WEBHOOK_URI` to the Power Automate webhook URL. When both
+`BID-Payload` and `NOTIFY_EMAIL` are provided, the processor posts a
+JSON payload to this endpoint to trigger downstream Flow steps.

--- a/fm_tool_core/constants.py
+++ b/fm_tool_core/constants.py
@@ -26,6 +26,7 @@ SMTP_PORT = os.getenv("SMTP_PORT")
 SMTP_USERNAME = os.getenv("SMTP_USERNAME")
 SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
 SMTP_FROM = os.getenv("SMTP_FROM")
+BID_WEBHOOK_URI = os.getenv("BID_WEBHOOK_URI")
 
 __all__ = [
     "READY_NAME",
@@ -46,4 +47,5 @@ __all__ = [
     "SMTP_USERNAME",
     "SMTP_PASSWORD",
     "SMTP_FROM",
+    "BID_WEBHOOK_URI",
 ]


### PR DESCRIPTION
## Summary
- add send_bid_webhook helper and BID webhook URI configuration
- trigger webhook for successful BID runs and test coverage

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9e32e55608333befb7748b931dbb4